### PR TITLE
save and restore the window poistion while parsing

### DIFF
--- a/autoload/sideways/parsing.vim
+++ b/autoload/sideways/parsing.vim
@@ -14,6 +14,7 @@
 "   [ [1, 14, 16], [1, 19, 21], [2, 3, 7] ]
 "
 function! sideways#parsing#Parse(definitions)
+  let viewpos = winsaveview()
   call sideways#util#PushCursor()
 
   let definitions = a:definitions
@@ -132,6 +133,7 @@ function! sideways#parsing#Parse(definitions)
 
   " call s:DebugItems(items)
 
+  call winrestview(viewpos)
   call sideways#util#PopCursor()
   return items
 endfunction

--- a/autoload/sideways/parsing.vim
+++ b/autoload/sideways/parsing.vim
@@ -15,7 +15,6 @@
 "
 function! sideways#parsing#Parse(definitions)
   let viewpos = winsaveview()
-  call sideways#util#PushCursor()
 
   let definitions = a:definitions
   let items       = []
@@ -23,7 +22,7 @@ function! sideways#parsing#Parse(definitions)
   let definition = s:LocateBestDefinition(definitions)
 
   if empty(definition)
-    call sideways#util#PopCursor()
+    call winrestview(viewpos)
     return []
   endif
 
@@ -134,7 +133,6 @@ function! sideways#parsing#Parse(definitions)
   " call s:DebugItems(items)
 
   call winrestview(viewpos)
-  call sideways#util#PopCursor()
   return items
 endfunction
 


### PR DESCRIPTION
One thing that I find frustrating is that sometimes performing Sideway functions will center my current line  in the window. I always loose the position of my cursor because of this side effect. This commit will save and restore the window position.