### PR TITLE
Allow angle bracket pattern to start with template <

### DIFF
--- a/plugin/sideways.vim
+++ b/plugin/sideways.vim
@@ -170,7 +170,7 @@ autocmd FileType cpp let b:sideways_definitions = [
       \     'brackets':  ['([{<''"', ')]}>''"'],
       \   },
       \   {
-      \     'start':     '\S\zs<\ze\S',
+      \     'start':     'template \zs<\ze\|\S\zs<\ze\S',
       \     'end':       '>',
       \     'delimiter': ',\_s*',
       \     'brackets':  ['([{<''"', ')]}>''"'],


### PR DESCRIPTION
The current support is just about right, but it is also common practice to put a space between the ``template`` keyword and the template parameters that follow - until now the plugin required that the ``<`` is surrounded by non-whitespace characters - I've only added an exception for ``template <``.

E.g.

```cpp
template <class B, class A>
struct S {};
```

After this commit the plugin will properly handle template parameters regardless of whether there is a separating space.