### PR TITLE
Add support for HTML class values

### DIFF
--- a/plugin/sideways.vim
+++ b/plugin/sideways.vim
@@ -91,6 +91,18 @@ autocmd FileType haml,slim let b:sideways_definitions = [
 
 autocmd FileType html let b:sideways_definitions = [
       \   {
+      \     'start':                   '\<class=''',
+      \     'end':                     '''',
+      \     'delimited_by_whitespace': 1,
+      \     'brackets':                ['"''', '"'''],
+      \   },
+      \   {
+      \     'start':                   '\<class="',
+      \     'end':                     '"',
+      \     'delimited_by_whitespace': 1,
+      \     'brackets':                ['"''', '"'''],
+      \   },
+      \   {
       \     'start':                   '<\k\+\_s\+',
       \     'end':                     '\s*/\?>',
       \     'delimited_by_whitespace': 1,

--- a/spec/plugin/html_attributes_spec.rb
+++ b/spec/plugin/html_attributes_spec.rb
@@ -156,4 +156,122 @@ describe "html attributes" do
       EOF
     end
   end
+
+  describe "has class but cursor outside" do
+    let(:filename) { 'test.html' }
+
+    before :each do
+      set_file_contents <<-EOF
+        <div class='foo' data-one='value' data-two='value'></div>
+      EOF
+
+      vim.set 'filetype', 'html'
+      vim.search('class')
+    end
+
+    specify "to the left" do
+      assert_file_contents <<-EOF
+        <div class='foo' data-one='value' data-two='value'></div>
+      EOF
+
+      vim.left
+      assert_file_contents <<-EOF
+        <div data-two='value' data-one='value' class='foo'></div>
+      EOF
+    end
+
+    specify "to the right" do
+      vim.right
+      assert_file_contents <<-EOF
+        <div data-one='value' class='foo' data-two='value'></div>
+      EOF
+
+      vim.right
+      assert_file_contents <<-EOF
+        <div data-one='value' data-two='value' class='foo'></div>
+      EOF
+    end
+  end
+
+  describe "cursor inside single quote class" do
+    let(:filename) { 'test.html' }
+
+    before :each do
+      set_file_contents <<-EOF
+        <div class='one two three'></div>
+      EOF
+
+      vim.set 'filetype', 'html'
+      vim.search('one')
+    end
+
+    specify "to the left" do
+      assert_file_contents <<-EOF
+        <div class='one two three'></div>
+      EOF
+
+      vim.left
+      assert_file_contents <<-EOF
+        <div class='three two one'></div>
+      EOF
+
+      vim.left
+      assert_file_contents <<-EOF
+        <div class='three one two'></div>
+      EOF
+    end
+
+    specify "to the right" do
+      vim.right
+      assert_file_contents <<-EOF
+        <div class='two one three'></div>
+      EOF
+
+      vim.right
+      assert_file_contents <<-EOF
+        <div class='two three one'></div>
+      EOF
+    end
+  end
+
+  describe "cursor inside double quote class" do
+    let(:filename) { 'test.html' }
+
+    before :each do
+      set_file_contents <<-EOF
+        <div class="one two three"></div>
+      EOF
+
+      vim.set 'filetype', 'html'
+      vim.search('one')
+    end
+
+    specify "to the left" do
+      assert_file_contents <<-EOF
+        <div class="one two three"></div>
+      EOF
+
+      vim.left
+      assert_file_contents <<-EOF
+        <div class="three two one"></div>
+      EOF
+
+      vim.left
+      assert_file_contents <<-EOF
+        <div class="three one two"></div>
+      EOF
+    end
+
+    specify "to the right" do
+      vim.right
+      assert_file_contents <<-EOF
+        <div class="two one three"></div>
+      EOF
+
+      vim.right
+      assert_file_contents <<-EOF
+        <div class="two three one"></div>
+      EOF
+    end
+  end
 end


### PR DESCRIPTION
This attempts to add support for html class values.

Inside will operate on values:
```html
<div id="app" class="▋min-h-screen bg-gray-200 antialiased xl:flex xl:flex-col xl:h-screen">
```
Outside will continue to work on attributes (current behavior):
```html
<div id="app" ▋class="min-h-screen bg-gray-200 antialiased xl:flex xl:flex-col xl:h-screen">
```

This currently doesn't work and I'm not sure why.