### PR TITLE
Tweaking defs from cucumber to apply to markdown and vimwiki

### DIFF
--- a/plugin/sideways.vim
+++ b/plugin/sideways.vim
@@ -346,6 +346,24 @@ autocmd FileType cucumber let b:sideways_definitions = [
       \   },
       \ ]
 
+autocmd FileType vimwiki let b:sideways_definitions = [
+      \   {
+      \     'start':     '^\s*|\s*',
+      \     'end':       '\s*|$',
+      \     'delimiter': '\s*|\s*',
+      \     'brackets':  ['(''"', ')''"'],
+      \   },
+      \ ]
+
+autocmd FileType markdown let b:sideways_definitions = [
+      \   {
+      \     'start':     '^\s*|\s*',
+      \     'end':       '\s*|$',
+      \     'delimiter': '\s*|\s*',
+      \     'brackets':  ['(''"', ')''"'],
+      \   },
+      \ ]
+
 autocmd FileType sh let b:sideways_definitions = [
       \   {
       \     'skip_syntax': ['shDoubleQuote', 'shSingleQuote', 'shComment'],


### PR DESCRIPTION
I copy your definitions of cucumber filetype to work to markdown and vimwiki. It works apparently well. Good job with this plugin, easy to implement, I think doing a little tweaking for work with LaTeX tables.

PD: I am HotRatio1 from reddit, that one that asked about move markdown cells