### PR TITLE
Adding support for LaTeX tables, add delimiters, support for equations!

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ dict = {one: 1, two: 2, three: 3}
 let xs = [1;2;3]
 ```
 
-**LaTeX tabular**
+**LaTeX tabular:**
 ``` tex
 \begin{center}
   \begin{tabular}{ll}
@@ -140,7 +140,7 @@ let xs = [1;2;3]
 \end{center}
 ```
 
-**LaTeX align environment**
+**LaTeX align environment:**
 ``` tex
 \begin{align}
   a & b \\
@@ -148,7 +148,7 @@ let xs = [1;2;3]
 \end{align}
 ```
 
-**LaTeX equations and other delimiters**
+**LaTeX equations and other delimiters:**
 ``` tex
 \begin{gather}
   2 \pi = \tau \\
@@ -161,7 +161,7 @@ let xs = [1;2;3]
 \end{gather}
 ```
 
-**LaTeX inline math**
+**LaTeX inline math:**
 ``` tex
 Can switch item inside inline math \( x + 2 - 10 = \zeta - y \)
 this way too $ a + b = c $

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ border-radius: 20px 0 0 20px;
 {{parent/some-component one=two three="four" five=(action 'six')}}
 ```
 
-**Cucumber tables**:
+**Cucumber, Markdown and Vimwiki tables**:
 ``` cucumber
 Examples:
   | input_1 | input_2 | button | output |

--- a/README.md
+++ b/README.md
@@ -130,6 +130,43 @@ dict = {one: 1, two: 2, three: 3}
 let xs = [1;2;3]
 ```
 
+**LaTeX tabular**
+``` tex
+\begin{center}
+  \begin{tabular}{ll}
+    a & b \\
+    c & d
+  \end{tabular}
+\end{center}
+```
+
+**LaTeX align environment**
+``` tex
+\begin{align}
+  a & b \\
+  c & d 
+\end{align}
+```
+
+**LaTeX equations and other delimiters**
+``` tex
+\begin{gather}
+  2 \pi = \tau \\
+  | a + b | \leq |a| + |b| \\
+  [ \alpha + \beta + \gamma ]\\
+  \left| a < t + b > z \right|\\
+  \left( \zeta < \alpha + a + \beta \right)\\
+  \left[ (a + z) \geq c + b \right]\\
+  \{ \ldots  , a , b, c \}
+\end{gather}
+```
+
+**LaTeX inline math**
+``` tex
+Can switch item inside inline math \( x + 2 - 10 = \zeta - y \)
+this way too $ a + b = c $
+```
+
 The plugin is intended to be customizable, though at this point you'd need to
 look at the source to do this.
 

--- a/plugin/sideways.vim
+++ b/plugin/sideways.vim
@@ -357,16 +357,58 @@ autocmd FileType vimwiki let b:sideways_definitions = [
 
 autocmd FileType tex let b:sideways_definitions = [
       \   {
-      \     'start':     '^\s*',
-      \     'end':       '\s*\(\\\\\)\?\s*$',
-      \     'delimiter': '\s*&\s*',
-      \     'brackets':  ['$[(''"', '$])''"'],
+      \     'start':     '\\left\[\s*',
+      \     'end':       '\s*\\right\]',
+      \     'delimiter': '\s*\%([+\-,<>]\|\\leq\|\\geq\)\s*',
+      \     'brackets':  ['|[(', '|])'],
       \   },
       \   {
-      \     'start':     '\s\\\S\+{',
-      \     'end':       '}\s',
-      \     'delimiter': '\s*}{\s*',
-      \     'brackets':  ['$[(''"', '$])''"'],
+      \     'start':     '\\left(\s*',
+      \     'end':       '\s*\\right)',
+      \     'delimiter': '\s*\%([+\-,<>]\|\\leq\|\\geq\)\s*',
+      \     'brackets':  ['|[(', '|])'],
+      \   },
+      \   {
+      \     'start':     '\\left|\s*',
+      \     'end':       '\s*\\right|',
+      \     'delimiter': '\s*\%([+\-,<>]\|\\leq\|\\geq\)\s*',
+      \     'brackets':  ['|[(', '|])'],
+      \   },
+      \   {
+      \     'start':     '\\(\s*',
+      \     'end':       '\s*\\)',
+      \     'delimiter': '\s*\%([=+\-,<>]\|\\leq\|\\geq\)\s*',
+      \     'brackets':  ['|[(', '|])'],
+      \   },
+      \   {
+      \     'start':     '^\s*',
+      \     'end':       '\s*\(\\\\\)\?\s*$',
+      \     'delimiter': '\s*\%([&=+\-,<>]\|\\leq\|\\geq\)\s*',
+      \     'brackets':  ['$|[(', '$|])'],
+      \   },
+      \   {
+      \     'start':     '\[\s*',
+      \     'end':       '\s*\]',
+      \     'delimiter': '\s*\%([+\-,<>]\|\\leq\|\\geq\)\s*',
+      \     'brackets':  ['|[(', '|])'],
+      \   },
+      \   {
+      \     'start':     '(\s*',
+      \     'end':       '\s*)',
+      \     'delimiter': '\s*\%([+\-,<>]\|\\leq\|\\geq\)\s*',
+      \     'brackets':  ['|[(', '|])'],
+      \   },
+      \   {
+      \     'start':     '\\{\s*',
+      \     'end':       '\s*\\}',
+      \     'delimiter': '\s*\%([+\-,<>]\|\\leq\|\\geq\)\s*',
+      \     'brackets':  ['|[(', '|])'],
+      \   },
+      \   {
+      \     'start':     '\$\s*',
+      \     'end':       '\s*\$',
+      \     'delimiter': '\s*\%([=+\-,<>]\|\\leq\|\\geq\)\s*',
+      \     'brackets':  ['|[(', '|])'],
       \   },
       \ ]
 

--- a/plugin/sideways.vim
+++ b/plugin/sideways.vim
@@ -362,6 +362,12 @@ autocmd FileType tex let b:sideways_definitions = [
       \     'delimiter': '\s*&\s*',
       \     'brackets':  ['$[(''"', '$])''"'],
       \   },
+      \   {
+      \     'start':     '{',
+      \     'end':       '}\s*',
+      \     'delimiter': '\s*}{\s*',
+      \     'brackets':  ['$[(''"', '$])''"'],
+      \   },
       \ ]
 
 autocmd FileType sh let b:sideways_definitions = [

--- a/plugin/sideways.vim
+++ b/plugin/sideways.vim
@@ -355,6 +355,15 @@ autocmd FileType vimwiki let b:sideways_definitions = [
       \   },
       \ ]
 
+autocmd FileType markdown let b:sideways_definitions = [
+      \   {
+      \     'start':     '^\s*|\s*',
+      \     'end':       '\s*|$',
+      \     'delimiter': '\s*|\s*',
+      \     'brackets':  ['(''"', ')''"'],
+      \   },
+      \ ]
+
 autocmd FileType tex let b:sideways_definitions = [
       \   {
       \     'start':     '\\left\[\s*',

--- a/plugin/sideways.vim
+++ b/plugin/sideways.vim
@@ -355,12 +355,12 @@ autocmd FileType vimwiki let b:sideways_definitions = [
       \   },
       \ ]
 
-autocmd FileType markdown let b:sideways_definitions = [
+autocmd FileType tex let b:sideways_definitions = [
       \   {
-      \     'start':     '^\s*|\s*',
-      \     'end':       '\s*|$',
-      \     'delimiter': '\s*|\s*',
-      \     'brackets':  ['(''"', ')''"'],
+      \     'start':     '^\s*',
+      \     'end':       '\s*\(\\\\\)\?\s*$',
+      \     'delimiter': '\s*&\s*',
+      \     'brackets':  ['$[(''"', '$])''"'],
       \   },
       \ ]
 

--- a/plugin/sideways.vim
+++ b/plugin/sideways.vim
@@ -363,8 +363,8 @@ autocmd FileType tex let b:sideways_definitions = [
       \     'brackets':  ['$[(''"', '$])''"'],
       \   },
       \   {
-      \     'start':     '{',
-      \     'end':       '}\s*',
+      \     'start':     '\w{',
+      \     'end':       '}\s\+',
       \     'delimiter': '\s*}{\s*',
       \     'brackets':  ['$[(''"', '$])''"'],
       \   },

--- a/plugin/sideways.vim
+++ b/plugin/sideways.vim
@@ -363,8 +363,8 @@ autocmd FileType tex let b:sideways_definitions = [
       \     'brackets':  ['$[(''"', '$])''"'],
       \   },
       \   {
-      \     'start':     '\w{',
-      \     'end':       '}\s\+',
+      \     'start':     '\s\\\S\+{',
+      \     'end':       '}\s',
       \     'delimiter': '\s*}{\s*',
       \     'brackets':  ['$[(''"', '$])''"'],
       \   },


### PR DESCRIPTION
I add support to LaTeX tabular arrangement with "&" as separator and create definitions to work with basic mathematical operations as separators, added support for special delimiters in LaTeX such as: "\left[ \right]" , "\left( \right)" ,"$ $",etc. Finally added examples in the README.